### PR TITLE
Remove --no-commit flag from forge install commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install openzeppelin/openzeppelin-contracts@v5.0.1 --no-commit && forge install huff-language/huffmate --no-commit && forge install huff-language/foundry-huff --no-commit
+install :; forge install openzeppelin/openzeppelin-contracts@v5.0.1 && forge install huff-language/huffmate && forge install huff-language/foundry-huff
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
## Summary
- Removes `--no-commit` flag from forge install commands in Makefile

## Test plan
- [x] Verified `forge build` succeeds